### PR TITLE
Add support for initdb scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,16 @@ RUN curl http://www.h2database.com/h2-$RELEASE_DATE.zip -o h2.zip \
     && unzip h2.zip -d . \
     && rm h2.zip
 
+RUN ln -s $(ls /h2/bin/*jar) /h2/bin/h2.jar
+
+RUN mkdir /docker-entrypoint-initdb.d
+
 VOLUME /h2-data
 
-EXPOSE 8082 1521
+EXPOSE 8082 9092
 
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-CMD java -cp /h2/bin/h2*.jar org.h2.tools.Server \
- 	-web -webAllowOthers -webPort 8082 \
- 	-tcp -tcpAllowOthers -tcpPort 1521 \
-	-baseDir $H2DATA
+CMD java -cp /h2/bin/h2.jar org.h2.tools.Server \
+  -web -webAllowOthers -tcp -tcpAllowOthers -baseDir $H2DATA

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 buildo
+Copyright (c) 2018 buildo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,0 +1,74 @@
+# Docker image for H2
+
+A Docker image for the [H2 Database Engine](http://www.h2database.com/).
+
+## Versions
+
+Currently only the latest stable image is built, which according to
+[this page](http://www.h2database.com/html/download.html) is
+**Version 1.4.195 (2017-04-23)**.
+
+## How to use this image
+
+```sh
+docker run --name my-h2 -d buildo/h2database
+```
+
+The default TCP port 9092 is exposed, so standard container linking will make it
+automatically available to the linked containers.
+
+Use this JDBC string to connect from another container:
+
+```
+jdbc:h2:tcp://my-h2/my-db-name
+```
+
+## Using the web interface
+
+If you want to connect to the H2 web interface, bind the port 8082:
+
+```sh
+docker run --name my-h2 -p 8082:8082 -d buildo/h2database
+```
+
+Then in your browser open http://localhost:8082/ and use the following
+connection parameters:
+
+Driver Class: org.h2.Driver
+JDBC URL: jdbc:h2:my-db-name
+User Name: _(empty)_
+Password: _(empty)_
+
+## Environment Variables
+
+`H2DATA` specifies the location for the db files. If not set, `/h2-data` is used
+which is automatically created as an anonymous Docker volume.
+
+## Initialization scripts
+
+This image uses an initialization mechanism similar to the one used in the
+[official Postgres image](https://hub.docker.com/_/postgres/).
+
+You can add one or more `*.sql` or `*.sh` scripts under
+/docker-entrypoint-initdb.d (creating the directory if necessary). The image
+entrypoint script will run any `*.sql` files and source any `*.sh` scripts found
+in that directory to do further initialization before starting the service.
+
+The **name** of the `*.sql` files will be used as the name of the database. For
+example, to create a table named "FOOBAR" in the "baz" database, add the
+following content to `/docker-entrypoint-initdb.d/baz.sql`:
+
+```
+CREATE TABLE FOOBAR;
+```
+
+If you want to do something more complex, use a `.sh` script instead, for
+example adding the following content to `/docker-entrypoint-initdb.d/init.sh`:
+
+```
+#!/bin/bash
+
+java -cp /h2/bin/h2.jar org.h2.tools.RunScript \
+  -script /docker-entrypoint-initdb.d/baz \
+  -url "jdbc:h2:/h2-data/custom-db-name"
+```

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,27 @@
 #!/usr/bin/env bash
+set -e
 
-mkdir -p $H2DATA
+SERVER="java -cp /h2/bin/h2.jar org.h2.tools.Server"
+RUNSCRIPT="java -cp /h2/bin/h2.jar org.h2.tools.RunScript"
+
+runSql() {
+  filename=$(basename "$1")
+  db="${filename%.*}"
+  url="jdbc:h2:$H2DATA/$db"
+  echo "using url $url"
+  $RUNSCRIPT -script "$1" -url "$url"
+}
+
+mkdir -p "$H2DATA"
+
+echo
+for f in /docker-entrypoint-initdb.d/*; do
+  case "$f" in
+    *.sh)     echo "$0: running $f"; . "$f" ;;
+    *.sql)    echo "$0: running $f"; runSql "$f" ;;
+    *)        echo "$0: ignoring $f" ;;
+  esac
+  echo
+done
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,14 +14,19 @@ runSql() {
 
 mkdir -p "$H2DATA"
 
-echo
-for f in /docker-entrypoint-initdb.d/*; do
-  case "$f" in
-    *.sh)     echo "$0: running $f"; . "$f" ;;
-    *.sql)    echo "$0: running $f"; runSql "$f" ;;
-    *)        echo "$0: ignoring $f" ;;
-  esac
+if [ ! -f "$H2DATA/.initdb.completed" ]; then
+
   echo
-done
+  for f in /docker-entrypoint-initdb.d/*; do
+    case "$f" in
+      *.sh)     echo "$0: running $f"; . "$f" ;;
+      *.sql)    echo "$0: running $f"; runSql "$f" ;;
+      *)        echo "$0: ignoring $f" ;;
+    esac
+    echo
+  done
+  touch "$H2DATA/.initdb.completed"
+
+fi
 
 exec "$@"


### PR DESCRIPTION
This pull request adds the possibility to run SQL files and sh files in /docker-entrypoint-initdb.d -- this is similar to how the [official Docker image](https://hub.docker.com/_/postgres/) works and is useful to preload the database with seed data.

Other changes:

* use default TCP port (9092 instead of 1521)
* add documentation to README.md

## Test Plan

I built the image locally with these changes, then built a separate image extending this one:

Dockerfile:
```
FROM buildo/h2database

ADD *.sql /docker-entrypoint-initdb.d/
ADD *.sh /docker-entrypoint-initdb.d/
ADD baz /docker-entrypoint-initdb.d/
```

Output of `docker build -t h2test . && docker run --rm -it -p 8082:8082 h2test`:

```
Sending build context to Docker daemon    194kB
Step 1/4 : FROM buildo/h2database
 ---> 008f944a7bd2
Step 2/4 : ADD *.sql /docker-entrypoint-initdb.d/
 ---> ea650c76f707
Step 3/4 : ADD *.sh /docker-entrypoint-initdb.d/
 ---> 485638f57e98
Step 4/4 : ADD baz /docker-entrypoint-initdb.d/
 ---> 9b4947383699
Successfully built 9b4947383699
Successfully tagged h2test:latest

/usr/local/bin/docker-entrypoint.sh: ignoring /docker-entrypoint-initdb.d/baz

/usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/init.sh

/usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/od-persistent.sql
using url jdbc:h2:/h2-data/od-persistent

/usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/od-volatile.sql
using url jdbc:h2:/h2-data/od-volatile

TCP server running at tcp://172.17.0.3:9092 (others can connect)
Web Console server running at http://172.17.0.3:8082 (others can connect)
```

I then verified that connecting to the web console I could see all the databases and tables created by the init scripts:

![screen shot 2018-01-24 at 12 59 37](https://user-images.githubusercontent.com/474311/35331097-751213a6-0106-11e8-9805-868349a7a2c7.png)

![screen shot 2018-01-24 at 12 58 14](https://user-images.githubusercontent.com/474311/35331128-7c02eac8-0106-11e8-8ea9-3cb30516f98b.png)

![screen shot 2018-01-24 at 12 58 49](https://user-images.githubusercontent.com/474311/35331129-7c1b7520-0106-11e8-84f2-887294e2d7b8.png)

![screen shot 2018-01-24 at 12 59 24](https://user-images.githubusercontent.com/474311/35331130-7c339cd6-0106-11e8-997f-3bff13113005.png)
