### PR TITLE
Update H2 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 AS builder
+FROM ubuntu:22.04 AS builder
 
 ARG RELEASE_DATE=2022-06-13
 ARG RELEASE_VERSION=2.1.214

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
   && unzip h2.zip -d . \
   && cp h2/bin/h2-${RELEASE_VERSION}.jar /h2.jar
 
-FROM eclipse-temurin:8u372-b07-jre-focal
+FROM eclipse-temurin:21-jre-jammy
 
 ENV H2DATA /h2-data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04 AS builder
 
-ARG RELEASE_DATE=2022-06-13
-ARG RELEASE_VERSION=2.1.214
+ARG RELEASE_DATE=2023-09-17
+ARG RELEASE_VERSION=2.2.224
 
 RUN apt-get update \
   && apt-get install curl unzip -y \

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ A Docker image for the [H2 Database Engine](http://www.h2database.com/).
 
 ## Versions
 
-* **Version 2.1.214 (2022-06-13)**, the latest stable image, according to
+* **Version 2.2.224 (2023-09-17)**, the latest stable image, according to
 [this page](http://www.h2database.com/html/download.html)
+* **Version 2.1.214 (2022-06-13)**
 * **Version 1.4.195 (2017-04-23)**
 
 ## How to use this image


### PR DESCRIPTION
- Updated ubuntu builder to latest LTS: from 20.04 to 22.04
- Updated h2 to latest version 2023-09-17 2.2.224
- Updated jre to use latest LTS